### PR TITLE
Pass exec options into execa

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,10 +504,10 @@ Resolves to the index of the failing step recorded in a restore file.
 ```js
 import {exec} from '@dubstep/core';
 
-exec = (command: string) => Promise<string>;
+exec = (command: string, options: Object) => Promise<string>;
 ```
 
-Runs a CLI command in the shell and resolves to `stdout` output.
+Runs a CLI command in the shell and resolves to `stdout` output. Options provided are passed directly into [execa](https://github.com/sindresorhus/execa#options).
 
 ---
 

--- a/src/utils/exec.js
+++ b/src/utils/exec.js
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 import execa from 'execa';
 
-export const exec = async (command: string) => {
-  const {stdout} = await execa.shell(command);
+export const exec = async (command: string, options: Object = {}) => {
+  const {stdout} = await execa.shell(command, options);
   return stdout;
 };

--- a/src/utils/exec.test.js
+++ b/src/utils/exec.test.js
@@ -23,7 +23,12 @@ THE SOFTWARE.
 */
 
 import {exec} from './exec.js';
+import path from 'path';
 
 test('exec', async () => {
   await expect(exec('echo test')).resolves.toEqual('test');
+});
+
+test('exec with options', async () => {
+  await expect(exec('pwd', {cwd: __dirname})).resolves.toEqual(__dirname);
 });


### PR DESCRIPTION
My use case was specifying the `cwd` when spawning a test fixture